### PR TITLE
Dest: use addr family

### DIFF
--- a/ipvs.py
+++ b/ipvs.py
@@ -200,7 +200,7 @@ class Dest(object):
     def from_attr_list(lst, default_af=None):
         return Dest(
             d={
-                'ip': _from_af_union(lst.get('af', default_af),
+                'ip': _from_af_union(lst.get('addr_family', default_af),
                                      lst.get('addr')),
                 'weight': lst.get('weight'),
                 'port': lst.get('port'),

--- a/tests/ipvs_tests.py
+++ b/tests/ipvs_tests.py
@@ -7,9 +7,8 @@ from __future__ import unicode_literals
 
 from gnlpy.ipvs import IpvsClient
 
-import errno
-import os
 import unittest
+
 
 class TestAddingDest(unittest.TestCase):
 
@@ -23,6 +22,9 @@ class TestAddingDest(unittest.TestCase):
 
         # delete
         self.client.del_dest('1.1.1.1', 80, '2.2.2.1')
+
+        dests = self.client.get_pools()[0].dests()
+        self.assertTrue(dests[0].ip() == '2.2.2.2')
 
     def setUp(self):
         '''


### PR DESCRIPTION
We were wrongly using the `AF` attribute for `Dest`inations. This uses the right one.