### PR TITLE
[Kernel] Support STATS64 in recent ipvs stack

### DIFF
--- a/ipvs.py
+++ b/ipvs.py
@@ -51,6 +51,20 @@ IpvsStatsAttrList = netlink.create_attr_list_type(
     ('OUTBPS', netlink.U32Type),
 )
 
+IpvsStatsAttrList64 = netlink.create_attr_list_type(
+    'IpvsStatsAttrList64',
+    ('CONNS', netlink.U64Type),
+    ('INPKTS', netlink.U64Type),
+    ('OUTPKTS', netlink.U64Type),
+    ('INBYTES', netlink.U64Type),
+    ('OUTBYTES', netlink.U64Type),
+    ('CPS', netlink.U64Type),
+    ('INPPS', netlink.U64Type),
+    ('OUTPPS', netlink.U64Type),
+    ('INBPS', netlink.U64Type),
+    ('OUTBPS', netlink.U64Type),
+)
+
 IpvsServiceAttrList = netlink.create_attr_list_type(
     'IpvsServiceAttrList',
     ('AF', netlink.U16Type),
@@ -64,6 +78,7 @@ IpvsServiceAttrList = netlink.create_attr_list_type(
     ('NETMASK', netlink.U32Type),
     ('STATS', IpvsStatsAttrList),
     ('PE_NAME', netlink.NulStringType),
+    ('STATS64', IpvsStatsAttrList64),
 )
 
 IpvsDestAttrList = netlink.create_attr_list_type(
@@ -79,6 +94,7 @@ IpvsDestAttrList = netlink.create_attr_list_type(
     ('PERSIST_CONNS', netlink.U32Type),
     ('STATS', IpvsStatsAttrList),
     ('ADDR_FAMILY', netlink.U16Type),
+    ('STATS64', IpvsStatsAttrList64),
 )
 
 IpvsDaemonAttrList = netlink.create_attr_list_type(


### PR DESCRIPTION
Recent kernel add a 64bits version for all counters in the netlink reply.
Current code crash with folling error :
```bash
  $./ipvs-dump_ori.par
  File "/usr/local/fbcode/gcc-4.8.1-glibc-2.17-fb/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/fbcode/gcc-4.8.1-glibc-2.17-fb/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "__main__.py", line 642, in <module>
  File "__main__.py", line 494, in __invoke_main
  File "/usr/local/fbcode/gcc-4.8.1-glibc-2.17-fb/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/fbcode/gcc-4.8.1-glibc-2.17-fb/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "gnlpy/examples/ipvs_dump.py", line 61, in <module>
  File "gnlpy/examples/ipvs_dump.py", line 44, in main
  File "gnlpy/ipvs.py", line 483, in get_pools
  File "gnlpy/netlink.py", line 502, in query
  File "gnlpy/netlink.py", line 488, in _recv
  File "gnlpy/netlink.py", line 358, in deserialize_message
  File "gnlpy/netlink.py", line 312, in unpack
  File "gnlpy/netlink.py", line 249, in unpack
  File "gnlpy/netlink.py", line 246, in unpack
  KeyError: 12
```
I confirmed the new code worked on recent kernel.
On old kernel, I also ensure the output of the tool was the same.