### PR TITLE
Add module for obtaining load statistics from cgroupstats

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,5 @@
 Alex Gartrell
+Alexandre Dias (Outlyer)
 Anatolii Lapytskyi
 Emmanuel Bretelle
 Giuseppe Lavagetto

--- a/TARGETS
+++ b/TARGETS
@@ -31,3 +31,13 @@ python_library(
         ':netlink',
     ],
 )
+
+python_library(
+    name='cgroupstats',
+    srcs=[
+        'cgroupstats.py',
+    ],
+    deps=[
+        ':netlink',
+    ],
+)

--- a/__init__.py
+++ b/__init__.py
@@ -9,4 +9,4 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-__all__ = ['netlink', 'ipvs', 'taskstats']
+__all__ = ['netlink', 'ipvs', 'taskstats', 'cgroupstats']

--- a/cgroupstats.py
+++ b/cgroupstats.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+"""Cgroupstats module
+
+This module exists to expose the cgroupstats api to python
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# @lint-avoid-python-3-compatibility-imports
+# from __future__ import unicode_literals
+
+from contextlib import contextmanager
+import os
+import struct
+import gnlpy.netlink as netlink
+
+
+class Cgroupstats(object):
+    __fields__ = [
+        'nr_sleeping', 'nr_running', 'nr_stopped',
+        'nr_uninterruptible', 'nr_iowait'
+    ]
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+    def __repr__(self):
+        arr = ['%s=%s' % (f, repr(self.__dict__[f])) for f in self.__fields__]
+        return 'Cgroupstats(%s)' % ', '.join(arr)
+
+    @staticmethod
+    def unpack(val):
+        fmt = 'QQQQQ'  # as per __fields__ above, and they're uint64 each
+        attrs = dict(zip(Cgroupstats.__fields__, struct.unpack(fmt, val)))
+        return Cgroupstats(**attrs)
+
+
+CgroupstatsType = netlink.create_attr_list_type(
+    'CgroupstatsType',
+    ('CGROUP_STATS', Cgroupstats)
+)
+
+CgroupstatsCmdAttrList = netlink.create_attr_list_type(
+    'CgroupstatsAttrList',
+    ('CGROUPSTATS_CMD_ATTR_FD', netlink.U32Type),
+)
+
+
+CgroupstatsMessage = netlink.create_genl_message_type(
+    # the first field of the cgroupstats struct in the kernel is initialised to
+    # __TASKSTATS_CMD_MAX, which in turn has the value of 3. The second field,
+    # which is the GET command, will have a value of 4. In order for us to
+    # correctly pass this to the kernel, we need to pad the message. As our
+    # fields are initialised with values starting from 1, we need to insert
+    # 3 padding fields in order to have the GET command correspond to 4.
+    # see http://lxr.free-electrons.com/source/include/uapi/linux/cgroupstats.h
+    'CgroupstatsMessage', 'TASKSTATS',
+    ('PADDING1', None),
+    ('PADDING2', None),
+    ('PADDING3', None),
+    ('GET', CgroupstatsCmdAttrList),
+    ('NEW', CgroupstatsType),
+    required_modules=[],
+)
+
+
+class CgroupstatsClient(object):
+    """A python client to interact with cgroupstats
+    """
+
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+        self.nlsock = netlink.NetlinkSocket(verbose=verbose)
+
+    @contextmanager
+    def open_fd(self, path):
+        fd = os.open(path, os.O_RDONLY)
+        try:
+            yield fd
+        finally:
+            os.close(fd)
+
+    def get_cgroup_stats(self, path):
+        with self.open_fd(path) as fd:
+            data = CgroupstatsCmdAttrList(cgroupstats_cmd_attr_fd=fd)
+            message = CgroupstatsMessage(
+                'GET', flags=netlink.MessageFlags.REQUEST,
+                attr_list=data,
+            )
+            replies = self.nlsock.query(message)
+            return replies[0].get_attr_list().get('CGROUP_STATS')

--- a/examples/TARGETS
+++ b/examples/TARGETS
@@ -28,3 +28,15 @@ python_binary(
     ],
     main_module='gnlpy.examples.taskstats_dump',
 )
+
+python_binary(
+    name='cgroupstats-dump',
+    py_version='<3',
+    srcs=[
+        'cgroupstats_dump.py',
+    ],
+    deps=[
+        '@/gnlpy:cgropupstats',
+    ],
+    main_module='gnlpy.examples.cgroupstats_dump',
+)

--- a/examples/cgroupstats_dump.py
+++ b/examples/cgroupstats_dump.py
@@ -12,17 +12,17 @@ from __future__ import unicode_literals
 
 import argparse
 import sys
-from gnlpy.taskstats import TaskstatsClient
+from gnlpy.cgroupstats import CgroupstatsClient
 
 
 def main(argv):
     parser = argparse.ArgumentParser(
-        description='Show task information. Run as root.')
-    parser.add_argument('pid', type=int, help='The process id to show')
+        description='Show cgroup stats information. Run as root.')
+    parser.add_argument('path', type=str, help='Path to cgroup cpu hierarchy')
 
     args = parser.parse_args(argv[1:])
-    c = TaskstatsClient()
-    stats = c.get_pid_stats(args.pid)
+    c = CgroupstatsClient()
+    stats = c.get_cgroup_stats(args.path)
     print(stats)
 
 

--- a/examples/ipvs_dump.py
+++ b/examples/ipvs_dump.py
@@ -61,5 +61,6 @@ def main(argv):
             if args.dest is None or match_arg(args.dest, d.ip(), s.port()):
                 print('->', d)
 
+
 if __name__ == '__main__':
     main(sys.argv)

--- a/netlink.py
+++ b/netlink.py
@@ -145,6 +145,7 @@ def create_struct_fmt_type(fmt):
 
     return StructFmtType
 
+
 U8Type = create_struct_fmt_type('=B')
 U16Type = create_struct_fmt_type('=H')
 U32Type = create_struct_fmt_type('=I')
@@ -347,6 +348,7 @@ def create_genl_message_type(class_name, family_id_or_name, *fields,
 
     return MessageType
 
+
 # This is a global map of unpackers.  The @message_class decorator inserts
 # new message classes into this map so it can be used for the purpose of
 # deserializing netlink messages from NetlinkSocket::recv
@@ -397,6 +399,7 @@ def serialize_message(msg, port_id, seq):
     p = array.array(str('B'), t)
     p.extend(s)
     return p
+
 
 # In order to discover family IDs, we'll need to exchange some Ctrl
 # messages with the kernel.  We declare these message types and attribute
@@ -466,7 +469,7 @@ class ErrorMessage(object):
         error = struct.unpack(str('=i'), data[:4])[0]
         try:
             msg = deserialize_message(data[4:])
-        except:
+        except Exception:
             msg = None
         return ErrorMessage(error=error, msg=msg)
 

--- a/taskstats.py
+++ b/taskstats.py
@@ -57,6 +57,7 @@ class Taskstats(object):
         attrs['comm'] = attrs['comm'].rstrip('\0')
         return Taskstats(**attrs)
 
+
 TaskstatsType = netlink.create_attr_list_type(
     'TaskstatsType',
     ('PID', netlink.U32Type),

--- a/tests/cgroupstats_tests.py
+++ b/tests/cgroupstats_tests.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from gnlpy.cgroupstats import CgroupstatsClient
+
+import re
+import unittest
+
+
+CGROUP_PATH = '/proc/self/cgroup'
+CGROUP_CPU_PATH = '/sys/fs/cgroup/cpu/'
+
+
+def check_cpu_cgroup_presence():
+    with open(CGROUP_PATH, mode='r') as f:
+        file_contents = f.read()
+        if re.search('[,:]cpu[,:]', file_contents) is None:
+            return False
+        else:
+            return True
+
+
+CPU_CGROUP_PRESENT = check_cpu_cgroup_presence()
+
+
+class CgroupstatsTestCase(unittest.TestCase):
+
+    @unittest.skipUnless(CPU_CGROUP_PRESENT, "CPU cgroup is not present")
+    def test_get_cgroup_stats(self):
+        try:
+            client = CgroupstatsClient()
+            client.get_cgroup_stats(CGROUP_CPU_PATH)
+        except Exception as e:
+            self.fail("Raised unexpected exception: %s" % e)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/ipvs_tests.py
+++ b/tests/ipvs_tests.py
@@ -557,5 +557,6 @@ class TestHelperFunc(unittest.TestCase):
         with self.assertRaises(AssertionError):
             ipvs._from_proto_num(socket.IPPROTO_RSVP)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi guys,

This pull request adds a new module (very akin to taskstats.py) that allows load statistics to be obtained from cgroupstats. There's also an example script, which can be used like such:
```
$ sudo python2.7 examples/cgroupstats_dump.py /sys/fs/cgroup/cpu/
LoadStats(nr_sleeping=88, nr_running=0, nr_stopped=0,nr_uninterruptible=0, nr_iowait=0)
```

Let me know what you think!