### PR TITLE
Handle byte objects for python3.6+

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-14.04"
+  config.vm.box = "bento/ubuntu-16.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -69,6 +69,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
      sudo apt-get update
      sudo apt-get install -y python-pip python-dev
+     sudo pip install --upgrade pip
      sudo pip install coverage flake8 mock nose
      sudo bash -c 'grep -q ip_vs /etc/modules || echo ip_vs >> /etc/modules'
      sudo modprobe ip_vs

--- a/taskstats.py
+++ b/taskstats.py
@@ -54,7 +54,7 @@ class Taskstats(object):
         fmt = 'HIBBQQQQQQQQ32sQxxxIIIIIQQQQQQQQQQQQQQQQQQQQQQQ'
         attrs = dict(zip(Taskstats.__fields__, struct.unpack(fmt, val)))
         assert attrs['version'] == 8, "Bad version: %d" % attrs["version"]
-        attrs['comm'] = attrs['comm'].rstrip('\0')
+        attrs['comm'] = attrs['comm'].decode('utf-8').rstrip('\0')
         return Taskstats(**attrs)
 
 

--- a/tests/ipvs_tests.py
+++ b/tests/ipvs_tests.py
@@ -518,11 +518,11 @@ class TestMiscClasses(BaseJsonTestCase):
     def test_service_repr(self):
         s = self.pools[0].service()
         # non fwmark service
-        self.assertRegexpMatches(str(s), '^Service\(.*vip.*')
+        self.assertRegexpMatches(str(s), r'^Service\(.*vip.*')
 
         s = self.pools[2].service()
         # fwmark service
-        self.assertRegexpMatches(str(s), '^Service\(.*fwmark.*')
+        self.assertRegexpMatches(str(s), r'^Service\(.*fwmark.*')
 
 
 class TestHelperFunc(unittest.TestCase):


### PR DESCRIPTION
Changes:

1. Handle byte objects for python3.6+

2. Upgrade vagrant config to use ubuntu 16.04 at least so that updated packages (`six`) are available. In `14.04` `six` version `1.5.2` is installed which leads to:

```
ImportError: cannot import name wraps
```
Also using upgraded `pip` to suppress warnings.

3. Fixed flake8 errors for escape sequences

```
./tests/ipvs_tests.py:521:51: W605 invalid escape sequence '\('
./tests/ipvs_tests.py:525:51: W605 invalid escape sequence '\('
```

Please review.